### PR TITLE
fix torch version comparison

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,9 +15,9 @@ from torchao.utils import TorchAOBaseTensor, torch_version_at_least
 class TestTorchVersionAtLeast(unittest.TestCase):
     def test_torch_version_at_least(self):
         test_cases = [
-            ("2.5.0a0+git9f17037", "2.5.0", True),
+            ("2.5.0a0+git9f17037", "2.5.0", False),
             ("2.5.0a0+git9f17037", "2.4.0", True),
-            ("2.5.0.dev20240708+cu121", "2.5.0", True),
+            ("2.5.0.dev20240708+cu121", "2.5.0", False),
             ("2.5.0.dev20240708+cu121", "2.4.0", True),
             ("2.5.0", "2.4.0", True),
             ("2.5.0", "2.5.0", True),

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -6,10 +6,10 @@
 import functools
 import importlib
 import itertools
-import re
 import time
 from functools import reduce
 from importlib.metadata import version
+from packaging.version import Version
 from math import gcd
 from typing import Any, Callable, Optional
 
@@ -354,13 +354,8 @@ def _is_float8_type(dtype: torch.dtype) -> bool:
 
 
 def parse_version(version_string):
-    # Extract just the X.Y.Z part from the version string
-    match = re.match(r"(\d+\.\d+\.\d+)", version_string)
-    if match:
-        version = match.group(1)
-        return [int(x) for x in version.split(".")]
-    else:
-        raise ValueError(f"Invalid version string format: {version_string}")
+    """Return a :class:`Version` object for the given version string."""
+    return Version(version_string)
 
 
 def compare_versions(v1, v2):
@@ -768,7 +763,9 @@ def fill_defaults(args, n, defaults_tail):
 
 ## Deprecated, will be deleted in the future
 def _torch_version_at_least(min_version):
-    return is_fbcode() or version("torch") >= min_version
+    # Use the same implementation as :func:`torch_version_at_least` to handle
+    # development and local versions correctly.
+    return is_fbcode() or compare_versions(torch.__version__, min_version) >= 0
 
 
 # Supported AMD GPU Models and their LLVM gfx Codes:


### PR DESCRIPTION
## Summary
- handle development torch versions properly
- update torch version comparison tests

## Testing
- `pytest test/test_utils.py::TestTorchVersionAtLeast::test_torch_version_at_least -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.5.1 --quiet --index-url https://download.pytorch.org/whl/cpu` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689ba29d72ec83309d2a69cfac174184